### PR TITLE
Add namespace to action and service client names

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -36,6 +36,8 @@ public:
   : BT::ActionNodeBase(xml_tag_name, conf), action_name_(action_name)
   {
     node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
+    std::string node_namespace;
+    node_namespace = node_->get_namespace();
 
     // Initialize the input and output messages
     goal_ = typename ActionT::Goal();
@@ -44,6 +46,10 @@ public:
     std::string remapped_action_name;
     if (getInput("server_name", remapped_action_name)) {
       action_name_ = remapped_action_name;
+    }
+    // Append namespace to the action name
+    if(node_namespace.c_str()) {
+      action_name_ = node_namespace + "/" + action_name_;
     }
     createActionClient(action_name_);
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -35,6 +35,8 @@ public:
   : BT::SyncActionNode(service_node_name, conf), service_node_name_(service_node_name)
   {
     node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
+    std::string node_namespace;
+    node_namespace = node_->get_namespace();
 
     // Get the required items from the blackboard
     server_timeout_ =
@@ -43,6 +45,10 @@ public:
 
     // Now that we have node_ to use, create the service client for this BT service
     getInput("service_name", service_name_);
+    // Append namespace to the action name
+    if(node_namespace.c_str()) {
+      service_name_ = node_namespace + "/" + service_name_;
+    }
     service_client_ = node_->create_client<ServiceT>(service_name_);
 
     // Make sure the server is actually there before continuing


### PR DESCRIPTION
To run multiple agents/robots, the namespace of the node is appended to the
client names for bt action node and bt service node.

